### PR TITLE
[STUDY-004] 헥사고날 아키텍처로 애플리케이션 개발

### DIFF
--- a/src/main/java/com/bombo/splearn/adpater/integration/DummyEmailSender.java
+++ b/src/main/java/com/bombo/splearn/adpater/integration/DummyEmailSender.java
@@ -1,0 +1,14 @@
+package com.bombo.splearn.adpater.integration;
+
+import com.bombo.splearn.application.required.EmailSender;
+import com.bombo.splearn.domain.EmailVo;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DummyEmailSender implements EmailSender {
+
+    @Override
+    public void send(EmailVo email, String subject, String body) {
+
+    }
+}

--- a/src/main/java/com/bombo/splearn/adpater/security/DummyPasswordEncoder.java
+++ b/src/main/java/com/bombo/splearn/adpater/security/DummyPasswordEncoder.java
@@ -1,0 +1,18 @@
+package com.bombo.splearn.adpater.security;
+
+import com.bombo.splearn.domain.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DummyPasswordEncoder implements PasswordEncoder {
+
+    @Override
+    public String encode(String password) {
+        return "";
+    }
+
+    @Override
+    public boolean matches(String password, String passwordHash) {
+        return false;
+    }
+}

--- a/src/main/java/com/bombo/splearn/application/MemberService.java
+++ b/src/main/java/com/bombo/splearn/application/MemberService.java
@@ -1,0 +1,42 @@
+package com.bombo.splearn.application;
+
+import com.bombo.splearn.application.provided.MemberRegister;
+import com.bombo.splearn.application.required.EmailSender;
+import com.bombo.splearn.application.required.MemberRepository;
+import com.bombo.splearn.domain.EmailVo;
+import com.bombo.splearn.domain.Member;
+import com.bombo.splearn.domain.MemberCreateAction;
+import com.bombo.splearn.domain.PasswordEncoder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService implements MemberRegister {
+
+    private final MemberRepository memberRepository;
+    private final EmailSender emailSender;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public Member register(MemberCreateAction createAction) {
+        checkDuplicateEmail(createAction);
+
+        Member member = Member.register(createAction, passwordEncoder);
+        memberRepository.save(member);
+
+        sendWelcomeEmail(member);
+
+        return member;
+    }
+
+    private void sendWelcomeEmail(Member member) {
+        emailSender.send(member.getEmail(), "등록을 완료해주세요", "아래 링크를 클릭해서 등록을 완료해주세요");
+    }
+
+    private void checkDuplicateEmail(MemberCreateAction createAction) {
+        if (memberRepository.findByEmail(new EmailVo(createAction.email())).isPresent()) {
+            throw new IllegalStateException("이미 사용중인 이메일입니다: " + createAction.email());
+        }
+    }
+}

--- a/src/main/java/com/bombo/splearn/application/provided/MemberRegister.java
+++ b/src/main/java/com/bombo/splearn/application/provided/MemberRegister.java
@@ -1,0 +1,8 @@
+package com.bombo.splearn.application.provided;
+
+import com.bombo.splearn.domain.Member;
+import com.bombo.splearn.domain.MemberCreateAction;
+
+public interface MemberRegister {
+    Member register(MemberCreateAction action);
+}

--- a/src/main/java/com/bombo/splearn/application/required/EmailSender.java
+++ b/src/main/java/com/bombo/splearn/application/required/EmailSender.java
@@ -1,0 +1,7 @@
+package com.bombo.splearn.application.required;
+
+import com.bombo.splearn.domain.EmailVo;
+
+public interface EmailSender {
+    void send(EmailVo email, String subject, String body);
+}

--- a/src/main/java/com/bombo/splearn/application/required/MemberRepository.java
+++ b/src/main/java/com/bombo/splearn/application/required/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.bombo.splearn.application.required;
+
+import com.bombo.splearn.domain.EmailVo;
+import com.bombo.splearn.domain.Member;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
+
+public interface MemberRepository extends Repository<Member, Long> {
+    Member save(Member member);
+
+    Optional<Member> findByEmail(EmailVo email);
+}

--- a/src/main/java/com/bombo/splearn/domain/EmailVo.java
+++ b/src/main/java/com/bombo/splearn/domain/EmailVo.java
@@ -1,7 +1,9 @@
 package com.bombo.splearn.domain;
 
+import jakarta.persistence.Embeddable;
 import java.util.regex.Pattern;
 
+@Embeddable
 public record EmailVo(String email) {
 
     private static final Pattern EMAIL_PATTERN =

--- a/src/main/java/com/bombo/splearn/domain/Member.java
+++ b/src/main/java/com/bombo/splearn/domain/Member.java
@@ -1,17 +1,39 @@
 package com.bombo.splearn.domain;
 
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
 
 import static java.util.Objects.requireNonNull;
 import static org.springframework.util.Assert.state;
 
+@Entity
+@NaturalIdCache
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
+    @Id
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
     private Long id;
+
+    @NaturalId
+    @Embedded
     private EmailVo email;
+
     private String nickname;
+
     private String password;
+
+    @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
     @Builder
@@ -23,12 +45,11 @@ public class Member {
         this.status = status;
     }
 
-    public static Member create(Long id, String email, String nickname, String password, PasswordEncoder passwordEncoder) {
+    public static Member register(MemberCreateAction action, PasswordEncoder passwordEncoder) {
         return Member.builder()
-                .id(id)
-                .email(requireNonNull(email))
-                .nickname(requireNonNull(nickname))
-                .password(requireNonNull(passwordEncoder.encode(password)))
+                .email(requireNonNull(action.email()))
+                .nickname(requireNonNull(action.nickname()))
+                .password(requireNonNull(passwordEncoder.encode(action.password())))
                 .status(MemberStatus.PENDING)
                 .build();
     }
@@ -40,7 +61,7 @@ public class Member {
     }
 
     public void deactivate() {
-        state(status == MemberStatus.ACTIVATE, "ACTIVE 상태가 아닙니다");
+        state(status == MemberStatus.ACTIVATE, "ACTIVATED 상태가 아닙니다");
 
         this.status = MemberStatus.DEACTIVATED;
     }

--- a/src/main/java/com/bombo/splearn/domain/MemberCreateAction.java
+++ b/src/main/java/com/bombo/splearn/domain/MemberCreateAction.java
@@ -1,6 +1,8 @@
 package com.bombo.splearn.domain;
 
 public record MemberCreateAction(
-
+    String email,
+    String password,
+    String nickname
 ) {
 }

--- a/src/test/java/com/bombo/splearn/application/provided/MemberRegisterTest.java
+++ b/src/test/java/com/bombo/splearn/application/provided/MemberRegisterTest.java
@@ -1,0 +1,39 @@
+package com.bombo.splearn.application.provided;
+
+import com.bombo.splearn.domain.Member;
+import com.bombo.splearn.domain.MemberFixture;
+import com.bombo.splearn.domain.MemberStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class MemberRegisterTest {
+
+    @Autowired
+    private MemberRegister memberRegister;
+
+    @Test
+    void register() {
+        Member member = memberRegister.register(MemberFixture.defaultMemberCreateAction());
+
+        assertThat(member.getId()).isNotNull();
+        assertThat(member.getStatus()).isEqualTo(MemberStatus.PENDING);
+    }
+
+    @Test
+    void duplicateEmailFail() {
+        Member member = memberRegister.register(MemberFixture.defaultMemberCreateAction());
+
+        assertThatThrownBy(() -> memberRegister.register(MemberFixture.defaultMemberCreateAction()))
+                .isInstanceOf(IllegalStateException.class);
+
+    }
+}

--- a/src/test/java/com/bombo/splearn/domain/MemberFixture.java
+++ b/src/test/java/com/bombo/splearn/domain/MemberFixture.java
@@ -1,0 +1,16 @@
+package com.bombo.splearn.domain;
+
+public class MemberFixture {
+
+    public static MemberCreateAction defaultMemberCreateAction(String email) {
+        return new MemberCreateAction(
+            email,
+            "password",
+            "bombo"
+        );
+    }
+
+    public static MemberCreateAction defaultMemberCreateAction() {
+        return defaultMemberCreateAction("bombo@github.com");
+    }
+}

--- a/src/test/java/com/bombo/splearn/domain/MemberTest.java
+++ b/src/test/java/com/bombo/splearn/domain/MemberTest.java
@@ -15,11 +15,11 @@ class MemberTest {
     @BeforeEach
     void setUp() {
         this.passwordEncoder = new FakePasswordEncoder();
-        member = Member.create(1L, "bombo-dev@github.com", "bombo", "password", passwordEncoder);
+        member = Member.register(MemberFixture.defaultMemberCreateAction(), passwordEncoder);
     }
 
     @Test
-    void createMember() {
+    void registerMember() {
         assertThat(member.getStatus()).isEqualTo(MemberStatus.PENDING);
     }
 

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+# @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL) ? ??
+#spring.test.constructor.autowire.mode=all


### PR DESCRIPTION
## 📚 강의 정보
- 강의 파트: `Part1 - [Section 4]`

---

## 🧭 학습 목적
이번 파트에서 어떤 내용을 다루고 있으며, 그중 어떤 내용을 깊이 이해하고자 했는지 정리합니다.

## 헥사고날 아키텍처의 오해
- 도메인 모델을 포함하고 있는 아키텍처는 헥사고날이 아니다. 클린 아키텍처이다. 
  - 일단 대부분 클린 아키텍처로 짜려고 하니 클린 아키텍처라 부르자.
- 포트&어댑터 패턴, 헥사고날 아키텍처는 사실 동일하다. 근데 사람들이 헥사고날이라는 모양에만 집중을 하더라. 그래서, 만든 사람이 헥사고날이라는 모양에 집중하지 말고 내 목적은 포트와 어댑터가 진짜 목적이여서 포트&어댑터가 마지막에 나왔다. 근데 억양이 헥사고날이 더 말하기 편하긴 하다. 그래서 아직까지도 포트&어댑터 보다 헥사고날이라고 부르는 사람이 많다.
- 사실, 헥사고날 아키텍처는 포트 & 어댑터만 명확하면 요구되는 명확한 패키지 구조는 없다. 자기가 만들어나가기 나름이다. 그 관점에서 토비님은 usecase라는 용어를 별로 안 좋아하신다고 하시더라. 만약 회원가입 유스케이스를 만든다고 한다면 MemberRegisterUsecase 라고 하기보다 MemberRegister 라고 port를 명시한다고 하신다.
  - 왜 그러실까. 생각을 좀 해봤는데 usecase라는게 사람마다 좀 정의하는게 다르다는 느낌을 최근에 대화를 나누면서 느낀 부분이 있다. 누군가는 유저 관점에서의 usecase를 생각하고 있고, 누군가는 시스템 관점에서의 usecase 를 생각하고 있다. 저마다 제 각각의 usecase를 생각하고 있으니 구현이 애매해진다.
  - 최근에, 내가 담당하고 있던 프로젝트에서도 그런 구분이 모호해서 바꾼 부분이 있다. 원래 Service 자체가 도메인 로직을 통합하여 무엇인가를 처리하는 Facade 로써 동작을 하는게 맞지만, 같은 도메인 애그리게이트의 조합으로 도메인이 생성되어야하고, 그 각 도메인이 다른 Entity로 분리가 되어있다고 한다면, 이 도메인을 합치는 Facade로써 고객의 행위가 별도로 처리가 되어야 한다. 그 관점에서 Domain을 명확하게 분리하거나 혹은 Domain과 하위 애그리게이트를 연관관계를 주입하여 루트 애그리게이트에서만 만들어지도록 할 수 있는데, 그렇다고 하기에는 domain.subXUpdate() 와 같은 여러가지 비즈니스 로직이 만들어진다. DDD 관점에서는 이게 의도된 방식일지는 모르겠으나, 도메인 코드의 복잡성이 올라간다는 단점이 있더라. 향후에 리팩토링을 한다면 어떠한 방향으로 하는게 좋을까?

## 표준 유효성 검사
- 강의에서는 Request 즉, DTO 라고 부르는 데이터 전달 객체에게 비즈니스 검증 로직을 위임한다. 이 방식이 좋은 방식일까? 에 대해서 생각해볼 필요가 있다. 물론, 어느정도의 Null, Empty, Blank 등은 충분히 해도 될 것 같은데, Size 같은 Request가 DTO의 검증 객체 있어야만 하는가, 현재는 RegisterRequest 라는 DTO에 Hibernate Validator를 사용해서 검증을 하고 있는데, UpdateRequest가 생기면 거기에도 동일한 Request가 추가되어야 한다.
- 이 시점에 우리는 이 검증 로직이 도메인의 불변식이라는 것을 알 수 있다. 물론, 나중에는 바뀔 가능성이 있기 때문에 일단 넘어가는게 좋을 것 같다. 강의의 진행 방식을 보다보면 토비님도 하나하나 순차적으로 점진적인 리팩토링을 선호하시는 것을 보니 나중이 되었을 때 바뀔 가능성이 충분히 존재한다고 본다. 바뀐다면 이렇게 바뀔지 궁금하기도 하다.

```java
public business(Request request) {
     Member member = Member.xxx();
     memberValidator.validate(member); // 불변식을 검증한다.
     memberRepository.save(member);
}
```

- 나는 이 스타일이 도메인에 대한 검증을 함께 처리해주어서 너무 좋은 것 같다는 생각이 든다. 하나 불편한 점이 있다면 각 도메인 서비스 로직 별로 다른 예외 메시지를 노출시켜주고 싶은데, 그런 부분이 조금 아쉽기는 하다.

---

## 🔀 나의 선택
강의에서 제시된 여러 설계 선택지 중, 나는 어떤 결정을 내렸는가?

- 선택지: 
- 내 선택: 
- 이유: 

---

## ⚖️ 트레이드오프 혹은 놓친 시점
해당 선택지에서 **놓쳤을 수 있는 부분**이나, 강의를 통해 새롭게 알게 된 **트레이드오프**가 있다면 정리합니다.

---

## 🤔 토비님의 선택
강의에서 제시된 선택과 그 배경은 무엇이었는가? 그리고 그 차이를 어떻게 이해했는가?

---

## 💬 남은 질문 및 고민
- `[예: 도메인 서비스와 애플리케이션 서비스는 어떻게 구분하는 게 좋은가?]`

---

## ✍️ 기타 메모
추가로 공유하고 싶은 내용, 인상 깊었던 문장, 참고자료 등을 자유롭게 적습니다.

- junit-platform.properties 를 통해서 별도의 옵션을 지정해줄 수 있는데, 이런 설정파일은 이게 왜 있는지를 다음 개발자가 그 파일을 봐야 알 수 있다. 만약, 해당 프로퍼티의 존재 이유를 모른다면 그냥 그 파일을 제거 할 수도 있다. 그 관점에서 코드에 애노테이션을 박아두는것이 다음 사람이 유지보수하거나 코드를 바라볼 떄 도움이 되지 않나 생각이 들기도 한다.

- @Column의 unique가 아니라 @NaturalId로써 unique 옵션을 줄 수 있더라. 실제 인조키가 아닌 방식으로 도메인을 처리하는데, 꽤 괜찮아보이는 것 같다. @NaturalIdCache 라는 애노테이션도 사용 할 만 한 것 같기도 하고, 다만, 실제로 이 Key를 우리는 NaturalId로 바라봐야하는가에 대한 의논은 필요한 것 같다. 키 관점에서는 중복을 허용하지 않는 Identity로써 동작 할 수 있는 값이라면..? 잘 이야기를 해보자.
- 특히, 별도의 ID를 생성해서 만드는 방식에서는 NaturalId가 많이 도움이 될 것 같다.

---
